### PR TITLE
[Tradfri] Translation fixes

### DIFF
--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
@@ -45,8 +45,15 @@ thing-type.config.tradfri.device.id.description = The identifier of the device o
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-pm25.description = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
+channel-type.tradfri.air-quality-rating.label = Air Quality
+channel-type.tradfri.air-quality-rating.description = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
+channel-type.tradfri.air-quality-rating.state.option.1 = Good
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Bad
+channel-type.tradfri.disable-led.label = Disable LED
+channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
 channel-type.tradfri.fan-mode.label = Fan Speed Mode
 channel-type.tradfri.fan-mode.description = Controls the configured fan speed.
 channel-type.tradfri.fan-mode.state.option.0 = Power Off
@@ -57,25 +64,17 @@ channel-type.tradfri.fan-mode.state.option.30 = Speed 3
 channel-type.tradfri.fan-mode.state.option.40 = Speed 4
 channel-type.tradfri.fan-mode.state.option.50 = Speed 5
 channel-type.tradfri.fan-speed.label = Current Fan Speed
-channel-type.tradfri.fan-speed.description = Provides the current fan speed.
-channel-type.tradfri.disable-led.label = Disable LED
-channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
-channel-type.tradfri.lock-button.label = Lock Physical Button
-channel-type.tradfri.lock-button.descripton = When ON, locks the physical button on the device.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
-channel-type.tradfri.air-quality-rating.label = Air Quality
-channel-type.tradfri.air-quality-rating.descripton = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
-channel-type.tradfri.air-quality-rating.state.option.1 = Good
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Bad
-channel-type.tradfri.filter-check-next.label = Next Filter Check
-channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
+channel-type.tradfri.fan-speed.description = Displays the current fan speed (0..50).
 channel-type.tradfri.filter-check-alarm.label = Filter Check Alarm
 channel-type.tradfri.filter-check-alarm.description = When this value is ON, you need to perform a filter check.
+channel-type.tradfri.filter-check-next.label = Next Filter Check
+channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
 channel-type.tradfri.filter-uptime.label = Filter Uptime
 channel-type.tradfri.filter-uptime.description = The duration for which the current filter was used.
-
+channel-type.tradfri.lock-button.label = Lock Physical Button
+channel-type.tradfri.lock-button.description = When ON, locks the physical button on the device.
+channel-type.tradfri.position.label = Position
+channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger�
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
-channel-type.tradfri.fan-mode.label = Modus der Lüftergeschwindigkeit
+channel-type.tradfri.air-quality-pm25.description = Vom Luftreiniger gemessene Partikeldichte von 2,5μm, in ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Eine Bewertung der Luftqualität zwischen 1 (gut) und 3 (schlecht).
+channel-type.tradfri.air-quality-rating.label = Luftqualität
+channel-type.tradfri.air-quality-rating.state.option.1 = Gut
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Schlecht
+channel-type.tradfri.disable-led.description = Deaktiviert die LEDs am Luftreiniger.
+channel-type.tradfri.disable-led.label = LED deaktivieren
 channel-type.tradfri.fan-mode.description = Steuert die konfigurierte Lüftergeschwindigkeit.
+channel-type.tradfri.fan-mode.label = Modus der Lüftergeschwindigkeit
 channel-type.tradfri.fan-mode.state.option.0 = Ausgeschaltet
 channel-type.tradfri.fan-mode.state.option.1 = Automatisch
 channel-type.tradfri.fan-mode.state.option.10 = Geschwindigkeit 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Geschwindigkeit 2
 channel-type.tradfri.fan-mode.state.option.30 = Geschwindigkeit 3
 channel-type.tradfri.fan-mode.state.option.40 = Geschwindigkeit 4
 channel-type.tradfri.fan-mode.state.option.50 = Geschwindigkeit 5
-channel-type.tradfri.fan-speed.label = Aktuelle Lüfterdrehzahl
 channel-type.tradfri.fan-speed.description = Zeigt die aktuelle Lüftergeschwindigkeit an.
-channel-type.tradfri.disable-led.label = LED deaktivieren
-channel-type.tradfri.disable-led.description = Deaktiviert die LEDs am Luftreiniger.
-channel-type.tradfri.lock-button.label = Physikalische Taste sperren
-channel-type.tradfri.lock-button.descripton = Wenn ON, wird die physische Taste am Gerät gesperrt.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Vom Luftreiniger gemessene Partikeldichte von 2,5μm, in ppm.
-channel-type.tradfri.air-quality-rating.label = Luftqualität
-channel-type.tradfri.air-quality-rating.descripton = Eine Bewertung der Luftqualität zwischen 1 (gut) und 3 (schlecht).
-channel-type.tradfri.air-quality-rating.state.option.1 = Gut
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Schlecht
-channel-type.tradfri.filter-check-next.label = Nächste Filterprüfung
-channel-type.tradfri.filter-check-next.description = Die Anzahl der Minuten bis zur nächsten Filterprüfung (oder die Zeit, seit der die Prüfung erforderlich ist, falls sie unter 0 liegt).
-channel-type.tradfri.filter-check-alarm.label = Filterprüfungsalarm
+channel-type.tradfri.fan-speed.label = Aktuelle Lüfterdrehzahl
 channel-type.tradfri.filter-check-alarm.description = Wenn dieser Wert ON ist, muss eine Filterprüfung durchgeführt werden.
-channel-type.tradfri.filter-uptime.label = Filterbetriebszeit
+channel-type.tradfri.filter-check-alarm.label = Filterprüfungsalarm
+channel-type.tradfri.filter-check-next.description = Die Anzahl der Minuten bis zur nächsten Filterprüfung (oder die Zeit, seit der die Prüfung erforderlich ist, falls sie unter 0 liegt).
+channel-type.tradfri.filter-check-next.label = Nächste Filterprüfung
 channel-type.tradfri.filter-uptime.description = Die Dauer, für die der aktuelle Filter verwendet wurde.
+channel-type.tradfri.filter-uptime.label = Filterbetriebszeit
+channel-type.tradfri.lock-button.description = Wenn ON, wird die physische Taste am Gerät gesperrt.
+channel-type.tradfri.lock-button.label = Physikalische Taste sperren
+channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
+channel-type.tradfri.position.label = Position
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = Laitteen tunniste tukiasemalla
 
 # channel types
 
-channel-type.tradfri.position.label = Asento
-channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
-channel-type.tradfri.fan-mode.label = Tuulettimen nopeustila
+channel-type.tradfri.air-quality-pm25.description = Ilmanpuhdistimen mittaamien 2,5μm:n hiukkasten tiheys ppm:nä.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5 (hiukkaset)
+channel-type.tradfri.air-quality-rating.description = Ilmanlaadun arviointi välillä 1 (hyvä) - 3 (huono).
+channel-type.tradfri.air-quality-rating.label = Ilmanlaatu.
+channel-type.tradfri.air-quality-rating.state.option.1 = Hyvä.
+channel-type.tradfri.air-quality-rating.state.option.2 = OK.
+channel-type.tradfri.air-quality-rating.state.option.3 = Huono.
+channel-type.tradfri.disable-led.description = Poistaa ilmanpuhdistimen LED-valot käytöstä.
+channel-type.tradfri.disable-led.label = LEDin poistaminen käytöstä.
 channel-type.tradfri.fan-mode.description = Ohjaa määritettyä tuulettimen nopeutta.
+channel-type.tradfri.fan-mode.label = Tuulettimen nopeustila
 channel-type.tradfri.fan-mode.state.option.0 = Virta pois päältä
 channel-type.tradfri.fan-mode.state.option.1 = Automaattisesti
 channel-type.tradfri.fan-mode.state.option.10 = Speed 1 (Nopeus 1)
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Nopeus 2
 channel-type.tradfri.fan-mode.state.option.30 = Nopeus 3
 channel-type.tradfri.fan-mode.state.option.40 = Nopeus 4
 channel-type.tradfri.fan-mode.state.option.50 = Nopeus 5
-channel-type.tradfri.fan-speed.label = Nykyinen tuulettimen nopeus.
 channel-type.tradfri.fan-speed.description = Ilmoittaa tuulettimen nykyisen nopeuden.
-channel-type.tradfri.disable-led.label = LEDin poistaminen käytöstä.
-channel-type.tradfri.disable-led.description = Poistaa ilmanpuhdistimen LED-valot käytöstä.
-channel-type.tradfri.lock-button.label = Fyysisen painikkeen lukitseminen.
-channel-type.tradfri.lock-button.descripton = Kun se on päällä, se lukitsee laitteen fyysisen painikkeen.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5 (hiukkaset)
-channel-type.tradfri.air-quality-pm25.descripton = Ilmanpuhdistimen mittaamien 2,5μm:n hiukkasten tiheys ppm:nä.
-channel-type.tradfri.air-quality-rating.label = Ilmanlaatu.
-channel-type.tradfri.air-quality-rating.descripton = Ilmanlaadun arviointi välillä 1 (hyvä) - 3 (huono).
-channel-type.tradfri.air-quality-rating.state.option.1 = Hyvä.
-channel-type.tradfri.air-quality-rating.state.option.2 = OK.
-channel-type.tradfri.air-quality-rating.state.option.3 = Huono.
-channel-type.tradfri.filter-check-next.label = Seuraava suodatintarkistus
-channel-type.tradfri.filter-check-next.description = Seuraavaan suodatintarkistukseen edeltävien minuuttien määrä (tai aika tarkistuksen vaatimasta tarkistuksesta, jos se on alle 0).
-channel-type.tradfri.filter-check-alarm.label = Suodattimen tarkistushälytys.
+channel-type.tradfri.fan-speed.label = Nykyinen tuulettimen nopeus.
 channel-type.tradfri.filter-check-alarm.description = Kun tämä arvo on ON, suodatintarkistus on suoritettava.
-channel-type.tradfri.filter-uptime.label = Suodattimen käyttöaika
+channel-type.tradfri.filter-check-alarm.label = Suodattimen tarkistushälytys.
+channel-type.tradfri.filter-check-next.description = Seuraavaan suodatintarkistukseen edeltävien minuuttien määrä (tai aika tarkistuksen vaatimasta tarkistuksesta, jos se on alle 0).
+channel-type.tradfri.filter-check-next.label = Seuraava suodatintarkistus
 channel-type.tradfri.filter-uptime.description = Kesto, jonka ajan nykyistä suodatinta käytettiin.
+channel-type.tradfri.filter-uptime.label = Suodattimen käyttöaika
+channel-type.tradfri.lock-button.description = Kun se on päällä, se lukitsee laitteen fyysisen painikkeen.
+channel-type.tradfri.lock-button.label = Fyysisen painikkeen lukitseminen.
+channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
+channel-type.tradfri.position.label = Asento
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = Identifiant de l'équipement s
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
-channel-type.tradfri.fan-mode.label = Mode de vitesse du ventilateur
+channel-type.tradfri.air-quality-pm25.description = Densité des particules de 2,5μm mesurées par le purificateur d'air, en ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Évaluation de la qualité de l'air entre 1 (bonne) et 3 (mauvaise).
+channel-type.tradfri.air-quality-rating.label = Qualité de l'air
+channel-type.tradfri.air-quality-rating.state.option.1 = Bonne
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Mauvais
+channel-type.tradfri.disable-led.description = Désactive les LED du purificateur d'air.
+channel-type.tradfri.disable-led.label = Désactiver la LED
 channel-type.tradfri.fan-mode.description = Contrôle la vitesse configurée du ventilateur.
+channel-type.tradfri.fan-mode.label = Mode de vitesse du ventilateur
 channel-type.tradfri.fan-mode.state.option.0 = Mise hors tension
 channel-type.tradfri.fan-mode.state.option.1 = Automatique
 channel-type.tradfri.fan-mode.state.option.10 = Vitesse 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Vitesse 2
 channel-type.tradfri.fan-mode.state.option.30 = Vitesse 3
 channel-type.tradfri.fan-mode.state.option.40 = Vitesse 4
 channel-type.tradfri.fan-mode.state.option.50 = Vitesse 5
-channel-type.tradfri.fan-speed.label = Vitesse actuelle du ventilateur
 channel-type.tradfri.fan-speed.description = Fournit la vitesse actuelle du ventilateur.
-channel-type.tradfri.disable-led.label = Désactiver la LED
-channel-type.tradfri.disable-led.description = Désactive les LED du purificateur d'air.
-channel-type.tradfri.lock-button.label = Bouton physique de verrouillage
-channel-type.tradfri.lock-button.descripton = Lorsqu'il est ON, le bouton physique de l'appareil est verrouillé.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Densité des particules de 2,5μm mesurées par le purificateur d'air, en ppm.
-channel-type.tradfri.air-quality-rating.label = Qualité de l'air
-channel-type.tradfri.air-quality-rating.descripton = Évaluation de la qualité de l'air entre 1 (bonne) et 3 (mauvaise).
-channel-type.tradfri.air-quality-rating.state.option.1 = Bonne
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Mauvais
-channel-type.tradfri.filter-check-next.label = Prochain contrôle de filtre
-channel-type.tradfri.filter-check-next.description = Le nombre de minutes avant la prochaine vérification du filtre (ou le temps écoulé depuis la vérification si celui-ci est inférieur à 0).
-channel-type.tradfri.filter-check-alarm.label = Alarme de vérification du filtre
+channel-type.tradfri.fan-speed.label = Vitesse actuelle du ventilateur
 channel-type.tradfri.filter-check-alarm.description = Lorsque cette valeur est ON, vous devez effectuer une vérification du filtre.
-channel-type.tradfri.filter-uptime.label = Durée d'utilisation du filtre
+channel-type.tradfri.filter-check-alarm.label = Alarme de vérification du filtre
+channel-type.tradfri.filter-check-next.description = Le nombre de minutes avant la prochaine vérification du filtre (ou le temps écoulé depuis la vérification si celui-ci est inférieur à 0).
+channel-type.tradfri.filter-check-next.label = Prochain contrôle de filtre
 channel-type.tradfri.filter-uptime.description = La durée pendant laquelle le filtre actuel a été utilisé.
+channel-type.tradfri.filter-uptime.label = Durée d'utilisation du filtre
+channel-type.tradfri.lock-button.description = Lorsqu'il est ON, le bouton physique de l'appareil est verrouillé.
+channel-type.tradfri.lock-button.label = Bouton physique de verrouillage
+channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
+channel-type.tradfri.position.label = Position
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = L'identificatore del dispositi
 
 # channel types
 
-channel-type.tradfri.position.label = Posizione
-channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
-channel-type.tradfri.fan-mode.label = Modalità velocità ventola
+channel-type.tradfri.air-quality-pm25.description = Densità di particolato di 2,5μm misurata dal depuratore d'aria, in ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Valutazione della qualità dell'aria compresa tra 1 (buona) e 3 (cattiva).
+channel-type.tradfri.air-quality-rating.label = Qualità dell'aria
+channel-type.tradfri.air-quality-rating.state.option.1 = Buono
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Male
+channel-type.tradfri.disable-led.description = Disabilita i LED del depuratore d'aria.
+channel-type.tradfri.disable-led.label = Disabilita LED
 channel-type.tradfri.fan-mode.description = Controlla la velocità della ventola configurata.
+channel-type.tradfri.fan-mode.label = Modalità velocità ventola
 channel-type.tradfri.fan-mode.state.option.0 = Spegnimento
 channel-type.tradfri.fan-mode.state.option.1 = Automatico
 channel-type.tradfri.fan-mode.state.option.10 = Velocità 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Velocità 2
 channel-type.tradfri.fan-mode.state.option.30 = Velocità 3
 channel-type.tradfri.fan-mode.state.option.40 = Velocità 4
 channel-type.tradfri.fan-mode.state.option.50 = Velocità 5
-channel-type.tradfri.fan-speed.label = Velocità corrente della ventola
 channel-type.tradfri.fan-speed.description = Fornisce la velocità attuale della ventola.
-channel-type.tradfri.disable-led.label = Disabilita LED
-channel-type.tradfri.disable-led.description = Disabilita i LED del depuratore d'aria.
-channel-type.tradfri.lock-button.label = Pulsante di blocco fisico
-channel-type.tradfri.lock-button.descripton = Quando è attivo, blocca il pulsante fisico del dispositivo.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Densità di particolato di 2,5μm misurata dal depuratore d'aria, in ppm.
-channel-type.tradfri.air-quality-rating.label = Qualità dell'aria
-channel-type.tradfri.air-quality-rating.descripton = Valutazione della qualità dell'aria compresa tra 1 (buona) e 3 (cattiva).
-channel-type.tradfri.air-quality-rating.state.option.1 = Buono
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Male
-channel-type.tradfri.filter-check-next.label = Controllo filtro successivo
-channel-type.tradfri.filter-check-next.description = Numero di minuti prima del prossimo controllo del filtro (o tempo dal momento in cui il controllo è richiesto, se inferiore a 0).
-channel-type.tradfri.filter-check-alarm.label = Allarme controllo filtro
+channel-type.tradfri.fan-speed.label = Velocità corrente della ventola
 channel-type.tradfri.filter-check-alarm.description = Quando questo valore è ON, è necessario eseguire un controllo del filtro.
-channel-type.tradfri.filter-uptime.label = Tempo di attività del filtro
+channel-type.tradfri.filter-check-alarm.label = Allarme controllo filtro
+channel-type.tradfri.filter-check-next.description = Numero di minuti prima del prossimo controllo del filtro (o tempo dal momento in cui il controllo è richiesto, se inferiore a 0).
+channel-type.tradfri.filter-check-next.label = Controllo filtro successivo
 channel-type.tradfri.filter-uptime.description = Durata di utilizzo del filtro corrente.
+channel-type.tradfri.filter-uptime.label = Tempo di attività del filtro
+channel-type.tradfri.lock-button.description = Quando è attivo, blocca il pulsante fisico del dispositivo.
+channel-type.tradfri.lock-button.label = Pulsante di blocco fisico
+channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
+channel-type.tradfri.position.label = Posizione
 
 # discovery result
 


### PR DESCRIPTION
* Fixes Alphabetical order of properties
* Fixes a typo in some names

Note: Additions of the `^M` endings in `tradfri.properties` is coming from execution of `mvn spotless:check`