### PR TITLE
[tradfri] Air Purifier Fixes for Code Review number 2

### DIFF
--- a/bundles/org.openhab.binding.tradfri/README.md
+++ b/bundles/org.openhab.binding.tradfri/README.md
@@ -87,24 +87,24 @@ An air purifier supports:
 
 Refer to the matrix above.
 
-| Channel Type ID   | Item Type     | Description                                            |
-|-------------------|---------------|--------------------------------------------------------|
-| brightness        | Dimmer        | The brightness of the bulb in percent                  |
-| color_temperature | Dimmer        | color temperature from 0% = cold to 100% = warm        |
-| color             | Color         | full color                                             |
-| battery_level     | Number        | battery level (in %)                                   |
-| battery_low       | Switch        | battery low warning (<=10% = ON, >10% = OFF)           |
-| power             | Switch        | power switch                                           |
-| position          | Rollershutter | position of the blinds from 0% = open to 100% = closed |
-| fan_mode           | Number         | Fan Mode, target speed of the fan (0 = off, 1 = auto, 10..50 = Level 1 to 5)             |
-| fan_speed          | Number         | Current Fan Speed between 0 (off) and 50 (maximum speed)                                 |
-| disable_led        | Switch         | Disables the LED's on the device                                                         |
-| lock_button        | Switch         | Disables the physical button on the device (applications can still make changes)         |
-| air_quality_pm25   | Number         | Density of Particulate Matter of 2.5μm, measured in ppm                                  |
-| air_quality_rating | Number         | Gives a rating about air quality (1 = Good, 2 = OK, 3 = Bad) similar to Tradfri app      |
-| filter_check_next  | Number:Time    | Time in min before the next filter check if > 0, if < 0 you are late checking the filter |
-| filter_check_alarm | Switch         | When ON, you must perform a filter check (i.e. `filter_check_next` is < 0)               |
-| filter_uptime      | Number:Time    | Time elapsed since the last filter change, in min                                        |
+| Channel Type ID    | Item Type     | Description                                                                              |
+|--------------------|---------------|------------------------------------------------------------------------------------------|
+| brightness         | Dimmer        | The brightness of the bulb in percent                                                    |
+| color_temperature  | Dimmer        | color temperature from 0% = cold to 100% = warm                                          |
+| color              | Color         | full color                                                                               |
+| battery_level      | Number        | battery level (in %)                                                                     |
+| battery_low        | Switch        | battery low warning (<=10% = ON, >10% = OFF)                                             |
+| power              | Switch        | power switch                                                                             |
+| position           | Rollershutter | position of the blinds from 0% = open to 100% = closed                                   |
+| fan_mode           | Number        | Fan Mode, target speed of the fan (0 = off, 1 = auto, 10..50 = Level 1 to 5)             |
+| fan_speed          | Number        | Current Fan Speed between 0 (off) and 50 (maximum speed)                                 |
+| disable_led        | Switch        | Disables the LED's on the device                                                         |
+| lock_button        | Switch        | Disables the physical button on the device (applications can still make changes)         |
+| air_quality_pm25   | Number        | Density of Particulate Matter of 2.5μm, measured in ppm                                  |
+| air_quality_rating | Number        | Gives a rating about air quality (1 = Good, 2 = OK, 3 = Bad) similar to Tradfri app      |
+| filter_check_next  | Number:Time   | Time in min before the next filter check if > 0, if < 0 you are late checking the filter |
+| filter_check_alarm | Switch        | When ON, you must perform a filter check (i.e. `filter_check_next` is < 0)               |
+| filter_uptime      | Number:Time   | Time elapsed since the last filter change, in min                                        |
 
 ## Full Example
 

--- a/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriBindingConstants.java
+++ b/bundles/org.openhab.binding.tradfri/src/main/java/org/openhab/binding/tradfri/internal/TradfriBindingConstants.java
@@ -56,8 +56,7 @@ public class TradfriBindingConstants {
 
     public static final Set<ThingTypeUID> SUPPORTED_BLINDS_TYPES_UIDS = Collections.singleton(THING_TYPE_BLINDS);
 
-    public static final Set<ThingTypeUID> SUPPORTED_AIR_PURIFIER_TYPES_UIDS = Collections
-            .singleton(THING_TYPE_AIR_PURIFIER);
+    public static final Set<ThingTypeUID> SUPPORTED_AIR_PURIFIER_TYPES_UIDS = Set.of(THING_TYPE_AIR_PURIFIER);
 
     // List of all Gateway Configuration Properties
     public static final String GATEWAY_CONFIG_HOST = "host";
@@ -240,9 +239,8 @@ public class TradfriBindingConstants {
     public static final int FAN_MODE_SPEED4 = 40;
     public static final int FAN_MODE_SPEED5 = 50;
 
-    public static final Set<Integer> AIR_PURIFIER_FANMODE = Collections
-            .unmodifiableSet(Stream.of(FAN_MODE_OFF, FAN_MODE_AUTO, FAN_MODE_SPEED1, FAN_MODE_SPEED2, FAN_MODE_SPEED3,
-                    FAN_MODE_SPEED4, FAN_MODE_SPEED5).collect(Collectors.toSet()));
+    public static final Set<Integer> AIR_PURIFIER_FANMODE = Set.of(FAN_MODE_OFF, FAN_MODE_AUTO, FAN_MODE_SPEED1,
+            FAN_MODE_SPEED2, FAN_MODE_SPEED3, FAN_MODE_SPEED4, FAN_MODE_SPEED5);
 
     public static final int AIR_PURIFIER_AIR_QUALITY_OK = 36;
     public static final int AIR_PURIFIER_AIR_QUALITY_BAD = 86;

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
@@ -5,6 +5,8 @@ addon.tradfri.description = This binding supports IKEA TRÅDFRI lighting devices
 
 # thing types
 
+thing-type.tradfri.0007.label = Air Purifier
+thing-type.tradfri.0007.description = This represents the air purifier sensors and controls.
 thing-type.tradfri.0010.label = On/Off Plug
 thing-type.tradfri.0010.description = A plug that can be switched on and off.
 thing-type.tradfri.0100.label = Dimmable Light
@@ -43,6 +45,34 @@ thing-type.config.tradfri.device.id.description = The identifier of the device o
 
 # channel types
 
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-pm25.description = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
+channel-type.tradfri.air-quality-rating.label = Air Quality
+channel-type.tradfri.air-quality-rating.description = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
+channel-type.tradfri.air-quality-rating.state.option.1 = Good
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Bad
+channel-type.tradfri.disable-led.label = Disable LED
+channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
+channel-type.tradfri.fan-mode.label = Fan Speed Mode
+channel-type.tradfri.fan-mode.description = Controls the configured fan speed.
+channel-type.tradfri.fan-mode.state.option.0 = Power Off
+channel-type.tradfri.fan-mode.state.option.1 = Automatic
+channel-type.tradfri.fan-mode.state.option.10 = Speed 1
+channel-type.tradfri.fan-mode.state.option.20 = Speed 2
+channel-type.tradfri.fan-mode.state.option.30 = Speed 3
+channel-type.tradfri.fan-mode.state.option.40 = Speed 4
+channel-type.tradfri.fan-mode.state.option.50 = Speed 5
+channel-type.tradfri.fan-speed.label = Current Fan Speed
+channel-type.tradfri.fan-speed.description = Displays the current fan speed (0..50).
+channel-type.tradfri.filter-check-alarm.label = Filter Check Alarm
+channel-type.tradfri.filter-check-alarm.description = When this value is ON, you need to perform a filter check.
+channel-type.tradfri.filter-check-next.label = Next Filter Check
+channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
+channel-type.tradfri.filter-uptime.label = Filter Uptime
+channel-type.tradfri.filter-uptime.description = The duration for which the current filter was used.
+channel-type.tradfri.lock-button.label = Lock Physical Button
+channel-type.tradfri.lock-button.description = When ON, locks the physical button on the device.
 channel-type.tradfri.position.label = Position
 channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
@@ -45,8 +45,15 @@ thing-type.config.tradfri.device.id.description = The identifier of the device o
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-pm25.description = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
+channel-type.tradfri.air-quality-rating.label = Air Quality
+channel-type.tradfri.air-quality-rating.description = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
+channel-type.tradfri.air-quality-rating.state.option.1 = Good
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Bad
+channel-type.tradfri.disable-led.label = Disable LED
+channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
 channel-type.tradfri.fan-mode.label = Fan Speed Mode
 channel-type.tradfri.fan-mode.description = Controls the configured fan speed.
 channel-type.tradfri.fan-mode.state.option.0 = Power Off
@@ -57,25 +64,17 @@ channel-type.tradfri.fan-mode.state.option.30 = Speed 3
 channel-type.tradfri.fan-mode.state.option.40 = Speed 4
 channel-type.tradfri.fan-mode.state.option.50 = Speed 5
 channel-type.tradfri.fan-speed.label = Current Fan Speed
-channel-type.tradfri.fan-speed.description = Provides the current fan speed.
-channel-type.tradfri.disable-led.label = Disable LED
-channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
-channel-type.tradfri.lock-button.label = Lock Physical Button
-channel-type.tradfri.lock-button.descripton = When ON, locks the physical button on the device.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
-channel-type.tradfri.air-quality-rating.label = Air Quality
-channel-type.tradfri.air-quality-rating.descripton = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
-channel-type.tradfri.air-quality-rating.state.option.1 = Good
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Bad
-channel-type.tradfri.filter-check-next.label = Next Filter Check
-channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
+channel-type.tradfri.fan-speed.description = Displays the current fan speed (0..50).
 channel-type.tradfri.filter-check-alarm.label = Filter Check Alarm
 channel-type.tradfri.filter-check-alarm.description = When this value is ON, you need to perform a filter check.
+channel-type.tradfri.filter-check-next.label = Next Filter Check
+channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
 channel-type.tradfri.filter-uptime.label = Filter Uptime
 channel-type.tradfri.filter-uptime.description = The duration for which the current filter was used.
-
+channel-type.tradfri.lock-button.label = Lock Physical Button
+channel-type.tradfri.lock-button.description = When ON, locks the physical button on the device.
+channel-type.tradfri.position.label = Position
+channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri.properties
@@ -5,8 +5,6 @@ addon.tradfri.description = This binding supports IKEA TRÅDFRI lighting devices
 
 # thing types
 
-thing-type.tradfri.0007.label = Air Purifier device
-thing-type.tradfri.0007.description = This represents the air purifier sensors and controls.
 thing-type.tradfri.0010.label = On/Off Plug
 thing-type.tradfri.0010.description = A plug that can be switched on and off.
 thing-type.tradfri.0100.label = Dimmable Light
@@ -45,34 +43,6 @@ thing-type.config.tradfri.device.id.description = The identifier of the device o
 
 # channel types
 
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.description = Density of Particulate Matter of 2.5μm measured by the Air Purifier, in ppm.
-channel-type.tradfri.air-quality-rating.label = Air Quality
-channel-type.tradfri.air-quality-rating.description = An evaluation of the Air Quality between 1 (Good) and 3 (Bad).
-channel-type.tradfri.air-quality-rating.state.option.1 = Good
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Bad
-channel-type.tradfri.disable-led.label = Disable LED
-channel-type.tradfri.disable-led.description = Disables the LED's on the Air Purifier.
-channel-type.tradfri.fan-mode.label = Fan Speed Mode
-channel-type.tradfri.fan-mode.description = Controls the configured fan speed.
-channel-type.tradfri.fan-mode.state.option.0 = Power Off
-channel-type.tradfri.fan-mode.state.option.1 = Automatic
-channel-type.tradfri.fan-mode.state.option.10 = Speed 1
-channel-type.tradfri.fan-mode.state.option.20 = Speed 2
-channel-type.tradfri.fan-mode.state.option.30 = Speed 3
-channel-type.tradfri.fan-mode.state.option.40 = Speed 4
-channel-type.tradfri.fan-mode.state.option.50 = Speed 5
-channel-type.tradfri.fan-speed.label = Current Fan Speed
-channel-type.tradfri.fan-speed.description = Displays the current fan speed (0..50).
-channel-type.tradfri.filter-check-alarm.label = Filter Check Alarm
-channel-type.tradfri.filter-check-alarm.description = When this value is ON, you need to perform a filter check.
-channel-type.tradfri.filter-check-next.label = Next Filter Check
-channel-type.tradfri.filter-check-next.description = The number of minutes before the next filter check (or time since check is required if below 0).
-channel-type.tradfri.filter-uptime.label = Filter Uptime
-channel-type.tradfri.filter-uptime.description = The duration for which the current filter was used.
-channel-type.tradfri.lock-button.label = Lock Physical Button
-channel-type.tradfri.lock-button.description = When ON, locks the physical button on the device.
 channel-type.tradfri.position.label = Position
 channel-type.tradfri.position.description = Control the position of the blind or curtain in percent from 0 (open) to 100 (closed).
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger�
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
-channel-type.tradfri.fan-mode.label = Modus der Lüftergeschwindigkeit
+channel-type.tradfri.air-quality-pm25.description = Vom Luftreiniger gemessene Partikeldichte von 2,5μm, in ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Eine Bewertung der Luftqualität zwischen 1 (gut) und 3 (schlecht).
+channel-type.tradfri.air-quality-rating.label = Luftqualität
+channel-type.tradfri.air-quality-rating.state.option.1 = Gut
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Schlecht
+channel-type.tradfri.disable-led.description = Deaktiviert die LEDs am Luftreiniger.
+channel-type.tradfri.disable-led.label = LED deaktivieren
 channel-type.tradfri.fan-mode.description = Steuert die konfigurierte Lüftergeschwindigkeit.
+channel-type.tradfri.fan-mode.label = Modus der Lüftergeschwindigkeit
 channel-type.tradfri.fan-mode.state.option.0 = Ausgeschaltet
 channel-type.tradfri.fan-mode.state.option.1 = Automatisch
 channel-type.tradfri.fan-mode.state.option.10 = Geschwindigkeit 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Geschwindigkeit 2
 channel-type.tradfri.fan-mode.state.option.30 = Geschwindigkeit 3
 channel-type.tradfri.fan-mode.state.option.40 = Geschwindigkeit 4
 channel-type.tradfri.fan-mode.state.option.50 = Geschwindigkeit 5
-channel-type.tradfri.fan-speed.label = Aktuelle Lüfterdrehzahl
 channel-type.tradfri.fan-speed.description = Zeigt die aktuelle Lüftergeschwindigkeit an.
-channel-type.tradfri.disable-led.label = LED deaktivieren
-channel-type.tradfri.disable-led.description = Deaktiviert die LEDs am Luftreiniger.
-channel-type.tradfri.lock-button.label = Physikalische Taste sperren
-channel-type.tradfri.lock-button.descripton = Wenn ON, wird die physische Taste am Gerät gesperrt.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Vom Luftreiniger gemessene Partikeldichte von 2,5μm, in ppm.
-channel-type.tradfri.air-quality-rating.label = Luftqualität
-channel-type.tradfri.air-quality-rating.descripton = Eine Bewertung der Luftqualität zwischen 1 (gut) und 3 (schlecht).
-channel-type.tradfri.air-quality-rating.state.option.1 = Gut
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Schlecht
-channel-type.tradfri.filter-check-next.label = Nächste Filterprüfung
-channel-type.tradfri.filter-check-next.description = Die Anzahl der Minuten bis zur nächsten Filterprüfung (oder die Zeit, seit der die Prüfung erforderlich ist, falls sie unter 0 liegt).
-channel-type.tradfri.filter-check-alarm.label = Filterprüfungsalarm
+channel-type.tradfri.fan-speed.label = Aktuelle Lüfterdrehzahl
 channel-type.tradfri.filter-check-alarm.description = Wenn dieser Wert ON ist, muss eine Filterprüfung durchgeführt werden.
-channel-type.tradfri.filter-uptime.label = Filterbetriebszeit
+channel-type.tradfri.filter-check-alarm.label = Filterprüfungsalarm
+channel-type.tradfri.filter-check-next.description = Die Anzahl der Minuten bis zur nächsten Filterprüfung (oder die Zeit, seit der die Prüfung erforderlich ist, falls sie unter 0 liegt).
+channel-type.tradfri.filter-check-next.label = Nächste Filterprüfung
 channel-type.tradfri.filter-uptime.description = Die Dauer, für die der aktuelle Filter verwendet wurde.
+channel-type.tradfri.filter-uptime.label = Filterbetriebszeit
+channel-type.tradfri.lock-button.description = Wenn ON, wird die physische Taste am Gerät gesperrt.
+channel-type.tradfri.lock-button.label = Physikalische Taste sperren
+channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
+channel-type.tradfri.position.label = Position
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_de.properties
@@ -5,8 +5,6 @@ addon.tradfri.description = Dieses Binding unterstützt IKEA TRÅDFRI Geräte ü
 
 # thing types
 
-thing-type.tradfri.0007.label = Luftreiniger-Gerät
-thing-type.tradfri.0007.description = Hier werden die Sensoren und Bedienelemente des Luftreinigers dargestellt.
 thing-type.tradfri.0010.label = Schaltbare Steckdose
 thing-type.tradfri.0010.description = Steckdose zum Ein- und Ausschalten von herkömmlichen Lampen oder anderen elektronischen Geräten.
 thing-type.tradfri.0100.label = Dimmbare Lampe (weiß)
@@ -45,36 +43,8 @@ thing-type.config.tradfri.device.id.description = ID zur Identifikation des Ger�
 
 # channel types
 
-channel-type.tradfri.air-quality-pm25.description = Vom Luftreiniger gemessene Partikeldichte von 2,5μm, in ppm.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-rating.description = Eine Bewertung der Luftqualität zwischen 1 (gut) und 3 (schlecht).
-channel-type.tradfri.air-quality-rating.label = Luftqualität
-channel-type.tradfri.air-quality-rating.state.option.1 = Gut
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Schlecht
-channel-type.tradfri.disable-led.description = Deaktiviert die LEDs am Luftreiniger.
-channel-type.tradfri.disable-led.label = LED deaktivieren
-channel-type.tradfri.fan-mode.description = Steuert die konfigurierte Lüftergeschwindigkeit.
-channel-type.tradfri.fan-mode.label = Modus der Lüftergeschwindigkeit
-channel-type.tradfri.fan-mode.state.option.0 = Ausgeschaltet
-channel-type.tradfri.fan-mode.state.option.1 = Automatisch
-channel-type.tradfri.fan-mode.state.option.10 = Geschwindigkeit 1
-channel-type.tradfri.fan-mode.state.option.20 = Geschwindigkeit 2
-channel-type.tradfri.fan-mode.state.option.30 = Geschwindigkeit 3
-channel-type.tradfri.fan-mode.state.option.40 = Geschwindigkeit 4
-channel-type.tradfri.fan-mode.state.option.50 = Geschwindigkeit 5
-channel-type.tradfri.fan-speed.description = Zeigt die aktuelle Lüftergeschwindigkeit an.
-channel-type.tradfri.fan-speed.label = Aktuelle Lüfterdrehzahl
-channel-type.tradfri.filter-check-alarm.description = Wenn dieser Wert ON ist, muss eine Filterprüfung durchgeführt werden.
-channel-type.tradfri.filter-check-alarm.label = Filterprüfungsalarm
-channel-type.tradfri.filter-check-next.description = Die Anzahl der Minuten bis zur nächsten Filterprüfung (oder die Zeit, seit der die Prüfung erforderlich ist, falls sie unter 0 liegt).
-channel-type.tradfri.filter-check-next.label = Nächste Filterprüfung
-channel-type.tradfri.filter-uptime.description = Die Dauer, für die der aktuelle Filter verwendet wurde.
-channel-type.tradfri.filter-uptime.label = Filterbetriebszeit
-channel-type.tradfri.lock-button.description = Wenn ON, wird die physische Taste am Gerät gesperrt.
-channel-type.tradfri.lock-button.label = Physikalische Taste sperren
-channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
 channel-type.tradfri.position.label = Position
+channel-type.tradfri.position.description = Steuert die Position des Rollos oder Vorhangs von 0 (offen) bis 100 (geschlossen).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = Laitteen tunniste tukiasemalla
 
 # channel types
 
-channel-type.tradfri.position.label = Asento
-channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
-channel-type.tradfri.fan-mode.label = Tuulettimen nopeustila
+channel-type.tradfri.air-quality-pm25.description = Ilmanpuhdistimen mittaamien 2,5μm:n hiukkasten tiheys ppm:nä.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5 (hiukkaset)
+channel-type.tradfri.air-quality-rating.description = Ilmanlaadun arviointi välillä 1 (hyvä) - 3 (huono).
+channel-type.tradfri.air-quality-rating.label = Ilmanlaatu.
+channel-type.tradfri.air-quality-rating.state.option.1 = Hyvä.
+channel-type.tradfri.air-quality-rating.state.option.2 = OK.
+channel-type.tradfri.air-quality-rating.state.option.3 = Huono.
+channel-type.tradfri.disable-led.description = Poistaa ilmanpuhdistimen LED-valot käytöstä.
+channel-type.tradfri.disable-led.label = LEDin poistaminen käytöstä.
 channel-type.tradfri.fan-mode.description = Ohjaa määritettyä tuulettimen nopeutta.
+channel-type.tradfri.fan-mode.label = Tuulettimen nopeustila
 channel-type.tradfri.fan-mode.state.option.0 = Virta pois päältä
 channel-type.tradfri.fan-mode.state.option.1 = Automaattisesti
 channel-type.tradfri.fan-mode.state.option.10 = Speed 1 (Nopeus 1)
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Nopeus 2
 channel-type.tradfri.fan-mode.state.option.30 = Nopeus 3
 channel-type.tradfri.fan-mode.state.option.40 = Nopeus 4
 channel-type.tradfri.fan-mode.state.option.50 = Nopeus 5
-channel-type.tradfri.fan-speed.label = Nykyinen tuulettimen nopeus.
 channel-type.tradfri.fan-speed.description = Ilmoittaa tuulettimen nykyisen nopeuden.
-channel-type.tradfri.disable-led.label = LEDin poistaminen käytöstä.
-channel-type.tradfri.disable-led.description = Poistaa ilmanpuhdistimen LED-valot käytöstä.
-channel-type.tradfri.lock-button.label = Fyysisen painikkeen lukitseminen.
-channel-type.tradfri.lock-button.descripton = Kun se on päällä, se lukitsee laitteen fyysisen painikkeen.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5 (hiukkaset)
-channel-type.tradfri.air-quality-pm25.descripton = Ilmanpuhdistimen mittaamien 2,5μm:n hiukkasten tiheys ppm:nä.
-channel-type.tradfri.air-quality-rating.label = Ilmanlaatu.
-channel-type.tradfri.air-quality-rating.descripton = Ilmanlaadun arviointi välillä 1 (hyvä) - 3 (huono).
-channel-type.tradfri.air-quality-rating.state.option.1 = Hyvä.
-channel-type.tradfri.air-quality-rating.state.option.2 = OK.
-channel-type.tradfri.air-quality-rating.state.option.3 = Huono.
-channel-type.tradfri.filter-check-next.label = Seuraava suodatintarkistus
-channel-type.tradfri.filter-check-next.description = Seuraavaan suodatintarkistukseen edeltävien minuuttien määrä (tai aika tarkistuksen vaatimasta tarkistuksesta, jos se on alle 0).
-channel-type.tradfri.filter-check-alarm.label = Suodattimen tarkistushälytys.
+channel-type.tradfri.fan-speed.label = Nykyinen tuulettimen nopeus.
 channel-type.tradfri.filter-check-alarm.description = Kun tämä arvo on ON, suodatintarkistus on suoritettava.
-channel-type.tradfri.filter-uptime.label = Suodattimen käyttöaika
+channel-type.tradfri.filter-check-alarm.label = Suodattimen tarkistushälytys.
+channel-type.tradfri.filter-check-next.description = Seuraavaan suodatintarkistukseen edeltävien minuuttien määrä (tai aika tarkistuksen vaatimasta tarkistuksesta, jos se on alle 0).
+channel-type.tradfri.filter-check-next.label = Seuraava suodatintarkistus
 channel-type.tradfri.filter-uptime.description = Kesto, jonka ajan nykyistä suodatinta käytettiin.
+channel-type.tradfri.filter-uptime.label = Suodattimen käyttöaika
+channel-type.tradfri.lock-button.description = Kun se on päällä, se lukitsee laitteen fyysisen painikkeen.
+channel-type.tradfri.lock-button.label = Fyysisen painikkeen lukitseminen.
+channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
+channel-type.tradfri.position.label = Asento
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fi.properties
@@ -5,8 +5,6 @@ addon.tradfri.description = Tämä lisäosa tulee IKEA TRÅDFRI-valaisimia IKEA-
 
 # thing types
 
-thing-type.tradfri.0007.label = Ilmanpuhdistinlaite.
-thing-type.tradfri.0007.description = Tämä edustaa ilmanpuhdistimen antureita ja ohjaimia.
 thing-type.tradfri.0010.label = Päällä/Pois päältä -pistorasia
 thing-type.tradfri.0010.description = Pistorasia, joka voidaan kytkeä päälle ja pois.
 thing-type.tradfri.0100.label = Himmennettävä valo
@@ -45,36 +43,8 @@ thing-type.config.tradfri.device.id.description = Laitteen tunniste tukiasemalla
 
 # channel types
 
-channel-type.tradfri.air-quality-pm25.description = Ilmanpuhdistimen mittaamien 2,5μm:n hiukkasten tiheys ppm:nä.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5 (hiukkaset)
-channel-type.tradfri.air-quality-rating.description = Ilmanlaadun arviointi välillä 1 (hyvä) - 3 (huono).
-channel-type.tradfri.air-quality-rating.label = Ilmanlaatu.
-channel-type.tradfri.air-quality-rating.state.option.1 = Hyvä.
-channel-type.tradfri.air-quality-rating.state.option.2 = OK.
-channel-type.tradfri.air-quality-rating.state.option.3 = Huono.
-channel-type.tradfri.disable-led.description = Poistaa ilmanpuhdistimen LED-valot käytöstä.
-channel-type.tradfri.disable-led.label = LEDin poistaminen käytöstä.
-channel-type.tradfri.fan-mode.description = Ohjaa määritettyä tuulettimen nopeutta.
-channel-type.tradfri.fan-mode.label = Tuulettimen nopeustila
-channel-type.tradfri.fan-mode.state.option.0 = Virta pois päältä
-channel-type.tradfri.fan-mode.state.option.1 = Automaattisesti
-channel-type.tradfri.fan-mode.state.option.10 = Speed 1 (Nopeus 1)
-channel-type.tradfri.fan-mode.state.option.20 = Nopeus 2
-channel-type.tradfri.fan-mode.state.option.30 = Nopeus 3
-channel-type.tradfri.fan-mode.state.option.40 = Nopeus 4
-channel-type.tradfri.fan-mode.state.option.50 = Nopeus 5
-channel-type.tradfri.fan-speed.description = Ilmoittaa tuulettimen nykyisen nopeuden.
-channel-type.tradfri.fan-speed.label = Nykyinen tuulettimen nopeus.
-channel-type.tradfri.filter-check-alarm.description = Kun tämä arvo on ON, suodatintarkistus on suoritettava.
-channel-type.tradfri.filter-check-alarm.label = Suodattimen tarkistushälytys.
-channel-type.tradfri.filter-check-next.description = Seuraavaan suodatintarkistukseen edeltävien minuuttien määrä (tai aika tarkistuksen vaatimasta tarkistuksesta, jos se on alle 0).
-channel-type.tradfri.filter-check-next.label = Seuraava suodatintarkistus
-channel-type.tradfri.filter-uptime.description = Kesto, jonka ajan nykyistä suodatinta käytettiin.
-channel-type.tradfri.filter-uptime.label = Suodattimen käyttöaika
-channel-type.tradfri.lock-button.description = Kun se on päällä, se lukitsee laitteen fyysisen painikkeen.
-channel-type.tradfri.lock-button.label = Fyysisen painikkeen lukitseminen.
-channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
 channel-type.tradfri.position.label = Asento
+channel-type.tradfri.position.description = Ohjaa kaihtimen tai verhon asentoa prosenteissa välillä 0 (auki) - 100 (kiinni).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
@@ -5,8 +5,6 @@ addon.tradfri.description = Cette extension apporte le support des appareils IKE
 
 # thing types
 
-thing-type.tradfri.0007.label = Purificateur d'air
-thing-type.tradfri.0007.description = Ceci représente le capteur et le contrôle du purificateur d'air.
 thing-type.tradfri.0010.label = Prise On/Off
 thing-type.tradfri.0010.description = Une prise qui peut être allumée et éteinte.
 thing-type.tradfri.0100.label = Ampoule Avec Variation
@@ -45,36 +43,8 @@ thing-type.config.tradfri.device.id.description = Identifiant de l'équipement s
 
 # channel types
 
-channel-type.tradfri.air-quality-pm25.description = Densité des particules de 2,5μm mesurées par le purificateur d'air, en ppm.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-rating.description = Évaluation de la qualité de l'air entre 1 (bonne) et 3 (mauvaise).
-channel-type.tradfri.air-quality-rating.label = Qualité de l'air
-channel-type.tradfri.air-quality-rating.state.option.1 = Bonne
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Mauvais
-channel-type.tradfri.disable-led.description = Désactive les LED du purificateur d'air.
-channel-type.tradfri.disable-led.label = Désactiver la LED
-channel-type.tradfri.fan-mode.description = Contrôle la vitesse configurée du ventilateur.
-channel-type.tradfri.fan-mode.label = Mode de vitesse du ventilateur
-channel-type.tradfri.fan-mode.state.option.0 = Mise hors tension
-channel-type.tradfri.fan-mode.state.option.1 = Automatique
-channel-type.tradfri.fan-mode.state.option.10 = Vitesse 1
-channel-type.tradfri.fan-mode.state.option.20 = Vitesse 2
-channel-type.tradfri.fan-mode.state.option.30 = Vitesse 3
-channel-type.tradfri.fan-mode.state.option.40 = Vitesse 4
-channel-type.tradfri.fan-mode.state.option.50 = Vitesse 5
-channel-type.tradfri.fan-speed.description = Fournit la vitesse actuelle du ventilateur.
-channel-type.tradfri.fan-speed.label = Vitesse actuelle du ventilateur
-channel-type.tradfri.filter-check-alarm.description = Lorsque cette valeur est ON, vous devez effectuer une vérification du filtre.
-channel-type.tradfri.filter-check-alarm.label = Alarme de vérification du filtre
-channel-type.tradfri.filter-check-next.description = Le nombre de minutes avant la prochaine vérification du filtre (ou le temps écoulé depuis la vérification si celui-ci est inférieur à 0).
-channel-type.tradfri.filter-check-next.label = Prochain contrôle de filtre
-channel-type.tradfri.filter-uptime.description = La durée pendant laquelle le filtre actuel a été utilisé.
-channel-type.tradfri.filter-uptime.label = Durée d'utilisation du filtre
-channel-type.tradfri.lock-button.description = Lorsqu'il est ON, le bouton physique de l'appareil est verrouillé.
-channel-type.tradfri.lock-button.label = Bouton physique de verrouillage
-channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
 channel-type.tradfri.position.label = Position
+channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_fr.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = Identifiant de l'équipement s
 
 # channel types
 
-channel-type.tradfri.position.label = Position
-channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
-channel-type.tradfri.fan-mode.label = Mode de vitesse du ventilateur
+channel-type.tradfri.air-quality-pm25.description = Densité des particules de 2,5μm mesurées par le purificateur d'air, en ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Évaluation de la qualité de l'air entre 1 (bonne) et 3 (mauvaise).
+channel-type.tradfri.air-quality-rating.label = Qualité de l'air
+channel-type.tradfri.air-quality-rating.state.option.1 = Bonne
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Mauvais
+channel-type.tradfri.disable-led.description = Désactive les LED du purificateur d'air.
+channel-type.tradfri.disable-led.label = Désactiver la LED
 channel-type.tradfri.fan-mode.description = Contrôle la vitesse configurée du ventilateur.
+channel-type.tradfri.fan-mode.label = Mode de vitesse du ventilateur
 channel-type.tradfri.fan-mode.state.option.0 = Mise hors tension
 channel-type.tradfri.fan-mode.state.option.1 = Automatique
 channel-type.tradfri.fan-mode.state.option.10 = Vitesse 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Vitesse 2
 channel-type.tradfri.fan-mode.state.option.30 = Vitesse 3
 channel-type.tradfri.fan-mode.state.option.40 = Vitesse 4
 channel-type.tradfri.fan-mode.state.option.50 = Vitesse 5
-channel-type.tradfri.fan-speed.label = Vitesse actuelle du ventilateur
 channel-type.tradfri.fan-speed.description = Fournit la vitesse actuelle du ventilateur.
-channel-type.tradfri.disable-led.label = Désactiver la LED
-channel-type.tradfri.disable-led.description = Désactive les LED du purificateur d'air.
-channel-type.tradfri.lock-button.label = Bouton physique de verrouillage
-channel-type.tradfri.lock-button.descripton = Lorsqu'il est ON, le bouton physique de l'appareil est verrouillé.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Densité des particules de 2,5μm mesurées par le purificateur d'air, en ppm.
-channel-type.tradfri.air-quality-rating.label = Qualité de l'air
-channel-type.tradfri.air-quality-rating.descripton = Évaluation de la qualité de l'air entre 1 (bonne) et 3 (mauvaise).
-channel-type.tradfri.air-quality-rating.state.option.1 = Bonne
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Mauvais
-channel-type.tradfri.filter-check-next.label = Prochain contrôle de filtre
-channel-type.tradfri.filter-check-next.description = Le nombre de minutes avant la prochaine vérification du filtre (ou le temps écoulé depuis la vérification si celui-ci est inférieur à 0).
-channel-type.tradfri.filter-check-alarm.label = Alarme de vérification du filtre
+channel-type.tradfri.fan-speed.label = Vitesse actuelle du ventilateur
 channel-type.tradfri.filter-check-alarm.description = Lorsque cette valeur est ON, vous devez effectuer une vérification du filtre.
-channel-type.tradfri.filter-uptime.label = Durée d'utilisation du filtre
+channel-type.tradfri.filter-check-alarm.label = Alarme de vérification du filtre
+channel-type.tradfri.filter-check-next.description = Le nombre de minutes avant la prochaine vérification du filtre (ou le temps écoulé depuis la vérification si celui-ci est inférieur à 0).
+channel-type.tradfri.filter-check-next.label = Prochain contrôle de filtre
 channel-type.tradfri.filter-uptime.description = La durée pendant laquelle le filtre actuel a été utilisé.
+channel-type.tradfri.filter-uptime.label = Durée d'utilisation du filtre
+channel-type.tradfri.lock-button.description = Lorsqu'il est ON, le bouton physique de l'appareil est verrouillé.
+channel-type.tradfri.lock-button.label = Bouton physique de verrouillage
+channel-type.tradfri.position.description = Contrôler la position du store ou du rideau en pourcentage de 0 (ouvert) à 100 (fermé).
+channel-type.tradfri.position.label = Position
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
@@ -5,8 +5,6 @@ addon.tradfri.description = Questo binding supporta i dispositivi luce IKEA TRÅ
 
 # thing types
 
-thing-type.tradfri.0007.label = Dispositivo di purificazione dell'aria
-thing-type.tradfri.0007.description = Rappresenta i sensori e i controlli del depuratore d'aria.
 thing-type.tradfri.0010.label = Presa Acceso/Spento
 thing-type.tradfri.0010.description = Una presa che può essere accesa e spenta.
 thing-type.tradfri.0100.label = Luce Regolabile
@@ -45,36 +43,8 @@ thing-type.config.tradfri.device.id.description = L'identificatore del dispositi
 
 # channel types
 
-channel-type.tradfri.air-quality-pm25.description = Densità di particolato di 2,5μm misurata dal depuratore d'aria, in ppm.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-rating.description = Valutazione della qualità dell'aria compresa tra 1 (buona) e 3 (cattiva).
-channel-type.tradfri.air-quality-rating.label = Qualità dell'aria
-channel-type.tradfri.air-quality-rating.state.option.1 = Buono
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Male
-channel-type.tradfri.disable-led.description = Disabilita i LED del depuratore d'aria.
-channel-type.tradfri.disable-led.label = Disabilita LED
-channel-type.tradfri.fan-mode.description = Controlla la velocità della ventola configurata.
-channel-type.tradfri.fan-mode.label = Modalità velocità ventola
-channel-type.tradfri.fan-mode.state.option.0 = Spegnimento
-channel-type.tradfri.fan-mode.state.option.1 = Automatico
-channel-type.tradfri.fan-mode.state.option.10 = Velocità 1
-channel-type.tradfri.fan-mode.state.option.20 = Velocità 2
-channel-type.tradfri.fan-mode.state.option.30 = Velocità 3
-channel-type.tradfri.fan-mode.state.option.40 = Velocità 4
-channel-type.tradfri.fan-mode.state.option.50 = Velocità 5
-channel-type.tradfri.fan-speed.description = Fornisce la velocità attuale della ventola.
-channel-type.tradfri.fan-speed.label = Velocità corrente della ventola
-channel-type.tradfri.filter-check-alarm.description = Quando questo valore è ON, è necessario eseguire un controllo del filtro.
-channel-type.tradfri.filter-check-alarm.label = Allarme controllo filtro
-channel-type.tradfri.filter-check-next.description = Numero di minuti prima del prossimo controllo del filtro (o tempo dal momento in cui il controllo è richiesto, se inferiore a 0).
-channel-type.tradfri.filter-check-next.label = Controllo filtro successivo
-channel-type.tradfri.filter-uptime.description = Durata di utilizzo del filtro corrente.
-channel-type.tradfri.filter-uptime.label = Tempo di attività del filtro
-channel-type.tradfri.lock-button.description = Quando è attivo, blocca il pulsante fisico del dispositivo.
-channel-type.tradfri.lock-button.label = Pulsante di blocco fisico
-channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
 channel-type.tradfri.position.label = Posizione
+channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/i18n/tradfri_it.properties
@@ -45,10 +45,17 @@ thing-type.config.tradfri.device.id.description = L'identificatore del dispositi
 
 # channel types
 
-channel-type.tradfri.position.label = Posizione
-channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
-channel-type.tradfri.fan-mode.label = Modalità velocità ventola
+channel-type.tradfri.air-quality-pm25.description = Densità di particolato di 2,5μm misurata dal depuratore d'aria, in ppm.
+channel-type.tradfri.air-quality-pm25.label = PM 2.5
+channel-type.tradfri.air-quality-rating.description = Valutazione della qualità dell'aria compresa tra 1 (buona) e 3 (cattiva).
+channel-type.tradfri.air-quality-rating.label = Qualità dell'aria
+channel-type.tradfri.air-quality-rating.state.option.1 = Buono
+channel-type.tradfri.air-quality-rating.state.option.2 = OK
+channel-type.tradfri.air-quality-rating.state.option.3 = Male
+channel-type.tradfri.disable-led.description = Disabilita i LED del depuratore d'aria.
+channel-type.tradfri.disable-led.label = Disabilita LED
 channel-type.tradfri.fan-mode.description = Controlla la velocità della ventola configurata.
+channel-type.tradfri.fan-mode.label = Modalità velocità ventola
 channel-type.tradfri.fan-mode.state.option.0 = Spegnimento
 channel-type.tradfri.fan-mode.state.option.1 = Automatico
 channel-type.tradfri.fan-mode.state.option.10 = Velocità 1
@@ -56,25 +63,18 @@ channel-type.tradfri.fan-mode.state.option.20 = Velocità 2
 channel-type.tradfri.fan-mode.state.option.30 = Velocità 3
 channel-type.tradfri.fan-mode.state.option.40 = Velocità 4
 channel-type.tradfri.fan-mode.state.option.50 = Velocità 5
-channel-type.tradfri.fan-speed.label = Velocità corrente della ventola
 channel-type.tradfri.fan-speed.description = Fornisce la velocità attuale della ventola.
-channel-type.tradfri.disable-led.label = Disabilita LED
-channel-type.tradfri.disable-led.description = Disabilita i LED del depuratore d'aria.
-channel-type.tradfri.lock-button.label = Pulsante di blocco fisico
-channel-type.tradfri.lock-button.descripton = Quando è attivo, blocca il pulsante fisico del dispositivo.
-channel-type.tradfri.air-quality-pm25.label = PM 2.5
-channel-type.tradfri.air-quality-pm25.descripton = Densità di particolato di 2,5μm misurata dal depuratore d'aria, in ppm.
-channel-type.tradfri.air-quality-rating.label = Qualità dell'aria
-channel-type.tradfri.air-quality-rating.descripton = Valutazione della qualità dell'aria compresa tra 1 (buona) e 3 (cattiva).
-channel-type.tradfri.air-quality-rating.state.option.1 = Buono
-channel-type.tradfri.air-quality-rating.state.option.2 = OK
-channel-type.tradfri.air-quality-rating.state.option.3 = Male
-channel-type.tradfri.filter-check-next.label = Controllo filtro successivo
-channel-type.tradfri.filter-check-next.description = Numero di minuti prima del prossimo controllo del filtro (o tempo dal momento in cui il controllo è richiesto, se inferiore a 0).
-channel-type.tradfri.filter-check-alarm.label = Allarme controllo filtro
+channel-type.tradfri.fan-speed.label = Velocità corrente della ventola
 channel-type.tradfri.filter-check-alarm.description = Quando questo valore è ON, è necessario eseguire un controllo del filtro.
-channel-type.tradfri.filter-uptime.label = Tempo di attività del filtro
+channel-type.tradfri.filter-check-alarm.label = Allarme controllo filtro
+channel-type.tradfri.filter-check-next.description = Numero di minuti prima del prossimo controllo del filtro (o tempo dal momento in cui il controllo è richiesto, se inferiore a 0).
+channel-type.tradfri.filter-check-next.label = Controllo filtro successivo
 channel-type.tradfri.filter-uptime.description = Durata di utilizzo del filtro corrente.
+channel-type.tradfri.filter-uptime.label = Tempo di attività del filtro
+channel-type.tradfri.lock-button.description = Quando è attivo, blocca il pulsante fisico del dispositivo.
+channel-type.tradfri.lock-button.label = Pulsante di blocco fisico
+channel-type.tradfri.position.description = Controlla la posizione della tenda in percentuale da 0 (aperto) a 100 (chiuso).
+channel-type.tradfri.position.label = Posizione
 
 # discovery result
 

--- a/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.tradfri/src/main/resources/OH-INF/thing/thing-types.xml
@@ -181,7 +181,7 @@
 			<bridge-type-ref id="gateway"/>
 		</supported-bridge-type-refs>
 
-		<label>Air Purifier device</label>
+		<label>Air Purifier</label>
 		<description>This represents the air purifier sensors and controls.</description>
 
 		<channels>
@@ -232,6 +232,7 @@
 
 		<label>Current Fan Speed</label>
 		<description>Displays the current fan speed (0..50).</description>
+		<category>Fan</category>
 
 		<state readOnly="true"/>
 	</channel-type>
@@ -279,6 +280,7 @@
 
 		<label>Next Filter Check</label>
 		<description>The number of minutes before the next filter check (or time since check is required if below 0).</description>
+		<category>Time</category>
 
 		<state readOnly="true" pattern="%.2f d"/>
 	</channel-type>
@@ -297,6 +299,7 @@
 
 		<label>Filter Uptime</label>
 		<description>The duration for which the current filter was used.</description>
+		<category>Time</category>
 
 		<state readOnly="true" pattern="%.2f week"/>
 	</channel-type>


### PR DESCRIPTION
Updates to the documentation to:
* Fix Item Types
* Fix abreviations (min -> minutes)
* Standardize `description` column of the `Channel Type ID` table
* Align the `Channel Type ID` table
* Improve the `Channels` > `Air Purifier` paragraph
* Align the non-ZLL capabilities table to similar format as ZLL One (uppercase first letter of each word; Align capabilities labels to `Channel Type ID` labels)